### PR TITLE
Add gRPC (and protobuf) dependencies for compilation.

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -33,5 +33,5 @@ jobs:
       working-directory: ${{github.workspace}}/build
       # Execute tests defined by the CMake configuration.
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: ctest -C ${{env.BUILD_TYPE}}
+      run: ctest -R "testlibraryintegration" -C ${{env.BUILD_TYPE}}
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ project(AutonomousTrucking VERSION 0.01
                   DESCRIPTION "A simulation for optimized truck transport control"
                   LANGUAGES CXX)
                   
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
 # Testing

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,26 @@
+
+find_package(Threads REQUIRED)
+
+message(STATUS "Using gRPC, protobuf and json via add_subdirectory (FetchContent).")
+
+include(FetchContent)
+
+# Fetching gRPC (includes Protobuf) 
+FetchContent_Declare(
+        grpc
+        GIT_REPOSITORY https://github.com/grpc/grpc.git
+        GIT_TAG        v1.52.0)
+FetchContent_MakeAvailable(grpc)
+
+
+
+
+set(_PROTOBUF_LIBPROTOBUF libprotobuf)
+set(_REFLECTION grpc++_reflection)
+set(_PROTOBUF_PROTOC $<TARGET_FILE:protoc>)
+set(_GRPC_GRPCPP grpc++)
+
+
 add_library(
         simulation
         point2d.h


### PR DESCRIPTION
Added CMake to include dependencies for gRPC and protobuf. 
Please check if this works on your machine by running (from the top level directory) `cmake -B build`. 